### PR TITLE
feat(login): add Traditional Chinese localization

### DIFF
--- a/codex-rs/tui/src/i18n.rs
+++ b/codex-rs/tui/src/i18n.rs
@@ -1,0 +1,19 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+static ZH_HANT: Lazy<HashMap<String, String>> = Lazy::new(|| {
+    let data = include_str!("i18n/zh-Hant.json");
+    serde_json::from_str::<HashMap<String, String>>(data).unwrap_or_default()
+});
+
+fn current_lang() -> String {
+    std::env::var("LANG").unwrap_or_default()
+}
+
+pub fn tr(key: &str) -> String {
+    if current_lang().starts_with("zh")
+        && let Some(v) = ZH_HANT.get(key) {
+            return v.clone();
+        }
+    key.to_string()
+}

--- a/codex-rs/tui/src/i18n/zh-Hant.json
+++ b/codex-rs/tui/src/i18n/zh-Hant.json
@@ -1,0 +1,55 @@
+{
+  "Ready": "就緒",
+  "Running": "執行中",
+  "Paused": "已暫停",
+  "Stopped": "已停止",
+  "Waiting": "等待中",
+  "Loading": "載入中",
+  "Completed": "已完成",
+  "Cancelled": "已取消",
+  "Failed": "失敗",
+  "Error": "發生錯誤",
+  "Warning": "警告",
+  "Info": "訊息",
+  "Success": "成功",
+
+  "Sign in with ChatGPT to continue.": "請先登入 ChatGPT 後繼續。",
+  "Paste an API key (or set as OPENAI_API_KEY)": "貼上 API Key（或設定 OPENAI_API_KEY）",
+  "Opening login page in your browser:": "正在瀏覽器開啟登入頁面：",
+  "Waiting for authentication… ctrl + c to quit": "等待驗證中…（Ctrl + C 以離開）",
+  "Login successful": "登入成功",
+  "Login failed": "登入失敗",
+
+  "Approve": "同意",
+  "Deny": "拒絕",
+  "This action requires your approval.": "此動作需要你的同意。",
+  "Approvals panel opened": "已開啟核准面板",
+  "No pending approvals": "目前沒有待核准項目",
+
+  "Press /mcp to manage Model Context Protocol": "輸入 /mcp 管理 MCP 連線",
+  "Current model": "目前模型",
+  "Model changed to {name}": "模型已切換為 {name}",
+
+  "Reasoning effort": "推理強度",
+  "minimal": "最小化",
+  "low": "低",
+  "medium": "中",
+  "high": "高",
+
+  "Executing command: {cmd}": "執行指令：{cmd}",
+  "Output saved to {path}": "輸出已儲存至 {path}",
+  "Command failed": "指令執行失敗",
+
+  "Network error": "網路錯誤",
+  "Timeout": "逾時",
+  "Invalid input": "輸入無效",
+
+  "Press Enter to continue": "按 Enter 繼續",
+  "Press Tab to autocomplete": "按 Tab 自動補全",
+  "Ctrl+H acts as Backspace": "Ctrl+H 可作為退格鍵",
+  "Ctrl-b / Ctrl-f to move cursor": "Ctrl-b / Ctrl-f 游標移動",
+
+  "Language file reloaded": "語言檔已重新載入",
+  "Failed to reload language file: {error}": "語言檔重新載入失敗：{error}",
+  "No language file configured": "尚未設定語言檔路徑"
+}

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -41,6 +41,7 @@ mod exec_command;
 mod file_search;
 mod get_git_diff;
 mod history_cell;
+mod i18n;
 pub mod insert_history;
 pub mod live_wrap;
 mod markdown;

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -24,6 +24,7 @@ use codex_login::AuthMode;
 use std::sync::RwLock;
 
 use crate::LoginStatus;
+use crate::i18n::tr;
 use crate::onboarding::onboarding_screen::KeyboardHandler;
 use crate::onboarding::onboarding_screen::StepStateProvider;
 use crate::shimmer::shimmer_spans;
@@ -211,7 +212,7 @@ impl AuthModeWidget {
         lines.push(
             // AE: Following styles.md, this should probably be Cyan because it's a user input tip.
             //     But leaving this for a future cleanup.
-            Line::from("  Press Enter to continue")
+            Line::from(tr("Press Enter to continue"))
                 .style(Style::default().add_modifier(Modifier::DIM)),
         );
         if let Some(err) = &self.error {
@@ -285,7 +286,7 @@ impl AuthModeWidget {
             ])
             .style(Style::default().add_modifier(Modifier::DIM)),
             Line::from(""),
-            Line::from("  Press Enter to continue").fg(Color::Cyan),
+            Line::from(tr("Press Enter to continue")).fg(Color::Cyan),
         ];
 
         Paragraph::new(lines)

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -17,6 +17,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::WidgetRef;
 use ratatui::widgets::Wrap;
 
+use crate::i18n::tr;
 use crate::onboarding::onboarding_screen::KeyboardHandler;
 use crate::onboarding::onboarding_screen::StepStateProvider;
 
@@ -106,7 +107,7 @@ impl WidgetRef for &TrustDirectoryWidget {
         }
         // AE: Following styles.md, this should probably be Cyan because it's a user input tip.
         //     But leaving this for a future cleanup.
-        lines.push(Line::from("  Press Enter to continue").add_modifier(Modifier::DIM));
+        lines.push(Line::from(tr("Press Enter to continue")).add_modifier(Modifier::DIM));
 
         Paragraph::new(lines)
             .wrap(Wrap { trim: false })


### PR DESCRIPTION
## Summary
- restore login success page to English and load translations at runtime
- add simple i18n helper for TUI with Traditional Chinese strings
- use translation lookup for onboarding prompts

## Testing
- `just fmt`
- `just fix -p codex-login`
- `just fix -p codex-tui`
- `cargo test -p codex-login`
- `cargo test -p codex-tui` *(fails: snapshot assertion for diff_render tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aae3417a8c832fb543090762df4a65