### PR TITLE
feat(exec): allow JSON mode via env var

### DIFF
--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -55,7 +55,8 @@ pub struct Cli {
     #[arg(long = "color", value_enum, default_value_t = Color::Auto)]
     pub color: Color,
 
-    /// Print events to stdout as JSONL.
+    /// Print events to stdout as JSONL. Can also be enabled by setting the
+    /// `CODEX_JSON` environment variable.
     #[arg(long = "json", default_value_t = false)]
     pub json: bool,
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -8,6 +8,7 @@ use std::io::Read;
 use std::path::PathBuf;
 
 pub use cli::Cli;
+pub const CODEX_JSON_ENV_VAR: &str = "CODEX_JSON";
 use codex_core::BUILT_IN_OSS_MODEL_PROVIDER_ID;
 use codex_core::ConversationManager;
 use codex_core::NewConversation;
@@ -50,6 +51,8 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         prompt,
         config_overrides,
     } = cli;
+
+    let json_mode = json_mode || std::env::var(CODEX_JSON_ENV_VAR).is_ok();
 
     // Determine the prompt based on CLI arg and/or stdin.
     let prompt = match prompt {


### PR DESCRIPTION
## Summary
- allow enabling JSONL output by setting the `CODEX_JSON` environment variable
- document `CODEX_JSON` in CLI help text

## Testing
- `just fmt`
- `just fix -p codex-exec`
- `cargo test -p codex-exec` *(fails: failed reading /tmp/.tmpAto8Tl/test.md: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3b707c68832fa54637869dd5a1ee