### PR TITLE
feat(tui): emit missing i18n event

### DIFF
--- a/codex-rs/tui/src/i18n.rs
+++ b/codex-rs/tui/src/i18n.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::Lazy;
+use serde_json::json;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
@@ -13,19 +14,30 @@ static MISSING: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::
 
 fn log_missing(key: &str) {
     if let Ok(mut missing) = MISSING.lock()
-        && missing.insert(key.to_string()) {
-            let path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/i18n/zh-Hant.missing.json");
-            let mut map: HashMap<String, String> = fs::read_to_string(path)
-                .ok()
-                .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_default();
-            if !map.contains_key(key) {
-                map.insert(key.to_string(), String::new());
-                if let Ok(json) = serde_json::to_string_pretty(&map) {
-                    let _ = fs::write(path, json);
-                }
+        && missing.insert(key.to_string())
+    {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/i18n/zh-Hant.missing.json");
+        let mut map: HashMap<String, String> = fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default();
+        if !map.contains_key(key) {
+            map.insert(key.to_string(), String::new());
+            if let Ok(json) = serde_json::to_string_pretty(&map) {
+                let _ = fs::write(path, json);
             }
         }
+        if std::env::var("CODEX_JSON").is_ok() {
+            let event = json!({
+                "id": "0",
+                "msg": {"type": "missing_i18n", "content": key}
+            });
+            #[allow(clippy::print_stdout)]
+            {
+                println!("{}", event);
+            }
+        }
+    }
 }
 
 fn current_lang() -> String {


### PR DESCRIPTION
## Summary
- emit `missing_i18n` JSON events when translations are missing in `CODEX_JSON` mode

## Testing
- `cargo test -p codex-tui` *(fails: pending snapshots)*
- `cargo insta pending-snapshots --manifest-path tui/Cargo.toml`
- `just fmt`
- `just fix -p codex-tui`


------
https://chatgpt.com/codex/tasks/task_e_68ab4dc94400832fbfc27b8662c8401f