### PR TITLE
chore: add missing zh-Hant translations

### DIFF
--- a/codex-rs/tui/src/i18n/zh-Hant.json
+++ b/codex-rs/tui/src/i18n/zh-Hant.json
@@ -26,6 +26,9 @@
   "Approvals panel opened": "已開啟核准面板",
   "No pending approvals": "目前沒有待核准項目",
 
+  "patch approval decision": "補丁核准決策",
+  "feedback": "回饋",
+
   "Press /mcp to manage Model Context Protocol": "輸入 /mcp 管理 MCP 連線",
   "Current model": "目前模型",
   "Model changed to {name}": "模型已切換為 {name}",
@@ -51,5 +54,31 @@
 
   "Language file reloaded": "語言檔已重新載入",
   "Failed to reload language file: {error}": "語言檔重新載入失敗：{error}",
-  "No language file configured": "尚未設定語言檔路徑"
+  "No language file configured": "尚未設定語言檔路徑",
+  "AGENTS files": "AGENTS 檔案",
+  "(none)": "（無）",
+  "Account": "帳號",
+  "Signed in with ChatGPT": "已使用 ChatGPT 登入",
+  "Login": "登入",
+  "Using API key. Run codex login to use ChatGPT plan": "使用 API key。執行 codex login 以使用 ChatGPT 方案",
+  "Plan": "方案",
+  "Model": "模型",
+  "Name": "名稱",
+  "Provider": "提供者",
+  "Reasoning summaries": "推理摘要",
+  "Token Usage": "Token 使用量",
+  "Session ID": "會話 ID",
+  "Input": "輸入",
+  "cached": "已快取",
+  "Output": "輸出",
+  "Total": "總計",
+  "MCP Tools": "MCP 工具",
+  "No MCP servers configured.": "未設定 MCP 伺服器。",
+  "See the": "請參考",
+  "to configure them.": "以進行設定。",
+  "No MCP tools available.": "無可用的 MCP 工具。",
+  "Server": "伺服器",
+  "Command": "指令",
+  "Env": "環境",
+  "Tools": "工具"
 }

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -29,6 +29,7 @@ use ratatui::widgets::Wrap;
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
 use crate::exec_command::strip_bash_lc_and_escape;
+use crate::i18n::tr;
 
 /// Request coming from the agent that needs user approval.
 pub(crate) enum ApprovalRequest {
@@ -340,11 +341,14 @@ impl UserApprovalWidget {
                 }
             }
             ApprovalRequest::ApplyPatch { .. } => {
-                lines.push(Line::from(format!("patch approval decision: {decision:?}")));
+                lines.push(Line::from(format!(
+                    "{}: {decision:?}",
+                    tr("patch approval decision")
+                )));
             }
         }
         if !feedback.trim().is_empty() {
-            lines.push(Line::from("feedback:"));
+            lines.push(Line::from(format!("{}:", tr("feedback"))));
             for l in feedback.lines() {
                 lines.push(Line::from(l.to_string()));
             }


### PR DESCRIPTION
## Summary
- localize status summary for AGENTS files, account info, model and token usage
- translate MCP configuration and tools sections

## Testing
- `cargo fmt`
- `cargo clippy -p codex-tui --fix --allow-dirty --allow-staged` *(interrupted: build running long)*
- `cargo test -p codex-tui` *(interrupted: build running long)*
- `cargo insta pending-snapshots -p codex-tui` *(failed: no such command `insta`)*


------
https://chatgpt.com/codex/tasks/task_e_68ab551247c4832f82fe61716ce152e4